### PR TITLE
lnd.py: add tests for and refactor create_wallet()

### DIFF
--- a/noma/lnd.py
+++ b/noma/lnd.py
@@ -3,11 +3,11 @@ LND related functionality
 """
 import pathlib
 import shutil
-from requests import get, post
-from base64 import b64encode
-from json import dumps
-from os import path
 from subprocess import call
+from os import path
+from json import dumps
+from base64 import b64encode
+from requests import get, post
 
 
 def check_wallet():
@@ -242,9 +242,9 @@ def _wallet_password():
 def _generate_and_save_seed():
     """Generate a wallet seed, save it to SEED_FILENAME, and return it"""
     mnemonic = None
-    r = get(URL_GENSEED, verify=TLS_CERT_PATH)
-    if r.status_code == 200:
-        json_seed_creation = r.json()
+    return_data = get(URL_GENSEED, verify=TLS_CERT_PATH)
+    if return_data.status_code == 200:
+        json_seed_creation = return_data.json()
         mnemonic = json_seed_creation["cipher_seed_mnemonic"]
         seed_file = open(SEED_FILENAME, "w")
         for word in mnemonic:
@@ -282,6 +282,7 @@ def _wallet_data(password_str):
             "cipher_seed_mnemonic": mnemonic,
             "wallet_password": b64encode(password_bytes).decode(),
         }
+    return {}
 
 
 def create_wallet():
@@ -317,8 +318,10 @@ def create_wallet():
     # Step 2: Create wallet
     if data:
         # Data is defined so proceed
-        r2 = post(URL_INITWALLET, verify=TLS_CERT_PATH, data=dumps(data))
-        if r2.status_code == 200:
+        return_data = post(
+            URL_INITWALLET, verify=TLS_CERT_PATH, data=dumps(data)
+        )
+        if return_data.status_code == 200:
             # If create wallet was successful
             print("Create wallet is successful")
         else:

--- a/noma/lnd.py
+++ b/noma/lnd.py
@@ -1,10 +1,13 @@
 """
 LND related functionality
 """
-from os import path
-from subprocess import call
 import pathlib
 import shutil
+from requests import get, post
+from base64 import b64encode
+from json import dumps
+from os import path
+from subprocess import call
 
 
 def check_wallet():
@@ -32,9 +35,6 @@ def check_wallet():
 
 def autounlock():
     """Autounlock lnd using sesame.txt, tls.cert"""
-    from json import dumps
-    from requests import post
-    from base64 import b64encode
 
     url = "https://localhost:8181/v1/unlockwallet"
     cert_path = "/media/important/important/lnd/tls.cert"
@@ -234,10 +234,6 @@ def create_wallet():
     rm -fr /media/important/important/lnd/data/chain/
     docker start compose_lndbox_1
     """
-    from requests import get, post
-    from base64 import b64encode
-    from json import dumps
-
     data = None
 
     # Check if there is an existing file, if not generate a random password
@@ -256,11 +252,7 @@ def create_wallet():
             password_file.close()
     else:
         # Get password from file if sesame file already exists
-        password_str = (
-            open(SESAME_PATH, "r")
-            .read()
-            .rstrip()
-        )
+        password_str = open(SESAME_PATH, "r").read().rstrip()
 
     # Convert password to byte encoded
     password_bytes = str(password_str).encode("utf-8")
@@ -297,7 +289,6 @@ def create_wallet():
         }
 
     # Step 2: Create wallet
-
     if data:
         # Data is defined so proceed
         r2 = post(URL_INITWALLET, verify=TLS_CERT_PATH, data=dumps(data))

--- a/noma/lnd.py
+++ b/noma/lnd.py
@@ -209,6 +209,81 @@ TEMP_PASSWORD_FILE_PATH = "/home/lncm/password.txt"
 SESAME_PATH = "/media/important/important/lnd/sesame.txt"
 
 
+def _write_password(password_str):
+    """Write a generated password to file, either the TEMP_PASSWORD_FILE_PATH
+    or the SESAME_PATH depending on whether SAVE_PASSWORD_CONTROL_FILE
+    exists."""
+    if not path.exists(SAVE_PASSWORD_CONTROL_FILE):
+        # Use tempory file if there is a password control file there
+        temp_password_file = open(TEMP_PASSWORD_FILE_PATH, "w")
+        temp_password_file.write(password_str)
+        temp_password_file.close()
+    else:
+        # Use sesame.txt if password_control_file exists
+        password_file = open(SESAME_PATH, "w")
+        password_file.write(password_str)
+        password_file.close()
+
+
+def _wallet_password():
+    """Either load the wallet password from SESAME_PATH, or generate a new
+    password, save it to file, and in either case return the password"""
+    # Check if there is an existing file, if not generate a random password
+    if not path.exists(SESAME_PATH):
+        # sesame file doesnt exist
+        password_str = randompass(string_length=15)
+        _write_password(password_str)
+    else:
+        # Get password from file if sesame file already exists
+        password_str = open(SESAME_PATH, "r").read().rstrip()
+    return password_str
+
+
+def _generate_and_save_seed():
+    """Generate a wallet seed, save it to SEED_FILENAME, and return it"""
+    mnemonic = None
+    r = get(URL_GENSEED, verify=TLS_CERT_PATH)
+    if r.status_code == 200:
+        json_seed_creation = r.json()
+        mnemonic = json_seed_creation["cipher_seed_mnemonic"]
+        seed_file = open(SEED_FILENAME, "w")
+        for word in mnemonic:
+            seed_file.write(word + "\n")
+        seed_file.close()
+    # Data doesnt get set if cant create the seed but that is fine, handle
+    # it later
+    return mnemonic
+
+
+def _load_seed():
+    """Load the wallet seed from SEED_FILENAME and return it"""
+    # Seed exists
+    seed_file = open(SEED_FILENAME, "r")
+    seed_file_words = seed_file.readlines()
+    mnemonic = []
+    for importword in seed_file_words:
+        mnemonic.append(importword.replace("\n", ""))
+    return mnemonic
+
+
+def _wallet_data(password_str):
+    """Build and return the wallet `data` dict with the mnemonic and wallet
+    password"""
+    # Convert password to byte encoded
+    password_bytes = str(password_str).encode("utf-8")
+    # Send request to generate seed if seed file doesnt exist
+    if not path.exists(SEED_FILENAME):
+        mnemonic = _generate_and_save_seed()
+    else:
+        mnemonic = _load_seed()
+    if mnemonic:
+        # Generate init wallet file from what was posted
+        return {
+            "cipher_seed_mnemonic": mnemonic,
+            "wallet_password": b64encode(password_bytes).decode(),
+        }
+
+
 def create_wallet():
     """
     Documented logic
@@ -234,59 +309,10 @@ def create_wallet():
     rm -fr /media/important/important/lnd/data/chain/
     docker start compose_lndbox_1
     """
-    data = None
-
-    # Check if there is an existing file, if not generate a random password
-    if not path.exists(SESAME_PATH):
-        # sesame file doesnt exist
-        password_str = randompass(string_length=15)
-        if not path.exists(SAVE_PASSWORD_CONTROL_FILE):
-            # Use tempory file if there is a password control file there
-            temp_password_file = open(TEMP_PASSWORD_FILE_PATH, "w")
-            temp_password_file.write(password_str)
-            temp_password_file.close()
-        else:
-            # Use sesame.txt if password_control_file exists
-            password_file = open(SESAME_PATH, "w")
-            password_file.write(password_str)
-            password_file.close()
-    else:
-        # Get password from file if sesame file already exists
-        password_str = open(SESAME_PATH, "r").read().rstrip()
-
-    # Convert password to byte encoded
-    password_bytes = str(password_str).encode("utf-8")
+    password_str = _wallet_password()
 
     # Step 1 get seed from web or file
-
-    # Send request to generate seed if seed file doesnt exist
-    if not path.exists(SEED_FILENAME):
-        r = get(URL_GENSEED, verify=TLS_CERT_PATH)
-        if r.status_code == 200:
-            json_seed_creation = r.json()
-            json_seed_mnemonic = json_seed_creation["cipher_seed_mnemonic"]
-            seed_file = open(SEED_FILENAME, "w")
-            for word in json_seed_mnemonic:
-                seed_file.write(word + "\n")
-            seed_file.close()
-            data = {
-                "cipher_seed_mnemonic": json_seed_mnemonic,
-                "wallet_password": b64encode(password_bytes).decode(),
-            }
-        # Data doesnt get set if cant create the seed but that is fine, handle
-        # it later
-    else:
-        # Seed exists
-        seed_file = open(SEED_FILENAME, "r")
-        seed_file_words = seed_file.readlines()
-        import_file_array = []
-        for importword in seed_file_words:
-            import_file_array.append(importword.replace("\n", ""))
-        # Generate init wallet file from what was posted
-        data = {
-            "cipher_seed_mnemonic": import_file_array,
-            "wallet_password": b64encode(password_bytes).decode(),
-        }
+    data = _wallet_data(password_str)
 
     # Step 2: Create wallet
     if data:

--- a/noma/lnd.py
+++ b/noma/lnd.py
@@ -240,10 +240,6 @@ def create_wallet():
 
     data = None
 
-    if not path.exists(SAVE_PASSWORD_CONTROL_FILE):
-        # Generate password but dont save it in usual spot
-        password_str = randompass(string_length=15)
-        temp_password_file = open(TEMP_PASSWORD_FILE_PATH, "w")
     # Check if there is an existing file, if not generate a random password
     if not path.exists(SESAME_PATH):
         # sesame file doesnt exist

--- a/tests/test_lnd.py
+++ b/tests/test_lnd.py
@@ -5,14 +5,6 @@ import random
 from unittest import mock
 from noma import lnd
 
-PATCH_MODULES = [
-    "requests.get",
-    "requests.post",
-    "base64.b64encode",
-    "json.dumps",
-    "os.path",
-]
-
 
 class TestComplete(Exception):
     """Raise me to stop the test, we're done"""
@@ -36,7 +28,7 @@ class LndCreateWalletTests(unittest.TestCase):
         pass
 
     def setUp(self):
-        self.mocks = {mod: mock.MagicMock() for mod in PATCH_MODULES}
+        pass
 
     def tearDown(self):
         pass
@@ -268,6 +260,8 @@ class LndCreateWalletTests(unittest.TestCase):
                 - wallet_password
             - requests.post() the `data` dict to lnd.URL_INITWALLET after
             dumping it to JSON
+        COVERAGE IMPROVEMENT OPPORUNITIES:
+            - test wallet_password is correctly read (earlier in the function)
         """
 
         def exists(call):

--- a/tests/test_lnd.py
+++ b/tests/test_lnd.py
@@ -14,7 +14,7 @@ PATCH_MODULES = [
 ]
 
 
-class Boom(Exception):
+class TestComplete(Exception):
     """Raise me to stop the test, we're done"""
 
     pass
@@ -45,8 +45,8 @@ class LndCreateWalletTests(unittest.TestCase):
     def test_checks_path(self, m_exists):
         """Check create_walet() checks whether the SAVE_PASSWORD_CONTROL_FILE
         exists"""
-        m_exists.side_effect = Boom
-        with self.assertRaises(Boom):
+        m_exists.side_effect = TestComplete
+        with self.assertRaises(TestComplete):
             lnd.create_wallet()
         m_exists.assert_called_with(lnd.SAVE_PASSWORD_CONTROL_FILE)
 
@@ -67,9 +67,9 @@ class LndCreateWalletTests(unittest.TestCase):
 
         m_exists.side_effect = pass_control
         m_open = mock.mock_open()
-        m_open.side_effect = Boom
+        m_open.side_effect = TestComplete
         with mock.patch("builtins.open", m_open):
-            with self.assertRaises(Boom):
+            with self.assertRaises(TestComplete):
                 lnd.create_wallet()
         m_exists.assert_called_with(lnd.SAVE_PASSWORD_CONTROL_FILE)
         m_rpass.assert_called_with(string_length=15)
@@ -96,9 +96,9 @@ class LndCreateWalletTests(unittest.TestCase):
         m_open = mock.mock_open()
         m_rpass.return_value = random.random()
         handle = m_open()
-        handle.close.side_effect = Boom
+        handle.close.side_effect = TestComplete
         with mock.patch("builtins.open", m_open):
-            with self.assertRaises(Boom):
+            with self.assertRaises(TestComplete):
                 lnd.create_wallet()
         m_exists.assert_any_call(lnd.SESAME_PATH)
         m_exists.assert_any_call(lnd.SAVE_PASSWORD_CONTROL_FILE)
@@ -130,9 +130,9 @@ class LndCreateWalletTests(unittest.TestCase):
         m_open = mock.mock_open()
         m_rpass.return_value = random.random()
         handle = m_open()
-        handle.close.side_effect = Boom
+        handle.close.side_effect = TestComplete
         with mock.patch("builtins.open", m_open):
-            with self.assertRaises(Boom):
+            with self.assertRaises(TestComplete):
                 lnd.create_wallet()
         m_exists.assert_any_call(lnd.SESAME_PATH)
         m_exists.assert_any_call(lnd.SAVE_PASSWORD_CONTROL_FILE)
@@ -146,7 +146,8 @@ class LndCreateWalletTests(unittest.TestCase):
         """
         Test that, if SESAME_PATH does exist, we:
             - read the password_str from SESAME_PATH
-            - .rstrip() the result
+        COVERAGE IMPROVEMENT OPPORTUNITY: also test that we:
+            - .rstrip() the password_str
         """
 
         def exists(call):
@@ -155,24 +156,145 @@ class LndCreateWalletTests(unittest.TestCase):
             if call == lnd.SAVE_PASSWORD_CONTROL_FILE:
                 # Don't want to go into that logic either
                 return True
+            if call == lnd.SEED_FILENAME:
+                raise TestComplete
             raise Unhappy(call)  # Should only have one of those calls
 
         m_exists.side_effect = exists
         m_open = mock.mock_open()
-        m_open.return_value = m_open_rv = mock.MagicMock()
-        m_open_rv.read = mock.MagicMock()
-        m_open_rv.read.rstrip = mock.MagicMock()
-        m_open_rv.read.rstrip.side_effect = Boom
-        # TODO: calling open().read().rstrip() should raise the `Boom`
-        # exception but it currently does not, resulting in the code proceeding
-        # to encode the password and check whether SEED_FILENAME exists, at
-        # which point exists() (above) raises the `Unhappy` exception
         with mock.patch("builtins.open", m_open):
-            with self.assertRaises(Boom):
+            with self.assertRaises(TestComplete):
                 lnd.create_wallet()
+        password_call = mock.call(lnd.SESAME_PATH, "r").read()
+        self.assertIn(password_call, m_open.mock_calls)
         m_exists.assert_any_call(lnd.SESAME_PATH)
-        m_open.assert_called_with(lnd.SESAME_PATH, "w")
-        m_open_rv.read.rstrip.assert_called_with()
+        m_open.assert_called_with(lnd.SESAME_PATH, "r")
+
+    @mock.patch("requests.get")
+    @mock.patch("os.path.exists")
+    def test_generates_seed(self, m_exists, m_get):
+        """
+        Test that, if SESAME_PATH does exist and we were able to get the
+        password_str earlier, and the SEED_FILENAME path does not exist, we
+        call get() to get a new seed
+        """
+
+        def exists(call):
+            if call == lnd.SESAME_PATH:
+                return True
+            if call == lnd.SAVE_PASSWORD_CONTROL_FILE:
+                # Don't want to go into that logic either
+                return True
+            if call == lnd.SEED_FILENAME:
+                return False
+            raise Unhappy(call)  # Should only have one of those calls
+
+        m_exists.side_effect = exists
+        m_open = mock.mock_open()
+        m_get.side_effect = TestComplete
+        with mock.patch("builtins.open", m_open):
+            with self.assertRaises(TestComplete):
+                lnd.create_wallet()
+        m_get.assert_called_with(lnd.URL_GENSEED, verify=lnd.TLS_CERT_PATH)
+
+    @mock.patch("requests.post")
+    @mock.patch("requests.get")
+    @mock.patch("os.path.exists")
+    def test_saves_seed(self, m_exists, m_get, m_post):
+        """
+        Test that, if we used get() to generate a new seed as above, and if
+        get().status_code == 200, we:
+            - call the .json() method on the get() return value
+            - get the "cipher_seed_mnemnonic" key in the resulting dict
+            - open the file at lnd.SEED_FILENAME for writing
+            - write the seed to file, one item in the cipher_seed_mnemonic
+            iterable per line
+            - close the file handle
+
+        COVERAGE IMPROVEMENT OPPORUNITIES:
+            - test that we actually check the status_code and do not proceed if
+            the code is not 200
+            - test that we correctly build the `data` dict
+        """
+
+        def exists(call):
+            if call == lnd.SESAME_PATH:
+                return True
+            if call == lnd.SAVE_PASSWORD_CONTROL_FILE:
+                # Don't want to go into that logic either
+                return True
+            if call == lnd.SEED_FILENAME:
+                return False
+            raise Unhappy(call)  # Should only have one of those calls
+
+        mnemonic = ["foo", "bar", "baz"]
+
+        class DummyResponse:
+            """Mocked-up Response for our get() function"""
+
+            status_code = 200
+
+            def __init__(self, *args, **kwargs):
+                pass
+
+            def json(self):
+                return {"cipher_seed_mnemonic": mnemonic}
+
+        m_exists.side_effect = exists
+        m_open = mock.mock_open()
+        m_get.side_effect = DummyResponse
+        m_post.side_effect = TestComplete
+        with mock.patch("builtins.open", m_open):
+            with self.assertRaises(TestComplete):
+                lnd.create_wallet()
+        m_get.assert_called_with(lnd.URL_GENSEED, verify=lnd.TLS_CERT_PATH)
+        handle = m_open()
+        for mne in mnemonic:
+            handle.write.assert_any_call(mne + "\n")
+        handle.close.assert_called_with()
+
+    @mock.patch("requests.post")
+    @mock.patch("requests.get")
+    @mock.patch("os.path.exists")
+    def test_loads_seed(self, m_exists, m_get, m_post):
+        """
+        Test that, if SEED_FILENAME does exist, we:
+            - do not call requests.get()
+            - open lnd.SEED_FILENAME for reading
+            - load every line in the resulting file into a list, stripping
+            newline characters
+            - build a `data` dict with the keys:
+                - cipher_seed_mnemonic
+                - wallet_password
+            - requests.post() the `data` dict to lnd.URL_INITWALLET after
+            dumping it to JSON
+        """
+
+        def exists(call):
+            if call == lnd.SESAME_PATH:
+                return True
+            if call == lnd.SAVE_PASSWORD_CONTROL_FILE:
+                # Don't want to go into that logic either
+                return True
+            if call == lnd.SEED_FILENAME:
+                return True
+            raise Unhappy(call)  # Should only have one of those calls
+
+        mnemonic = ["foo", "bar", "baz"]
+        file_contents = "\n".join(mnemonic)
+        m_exists.side_effect = exists
+        m_open = mock.mock_open(read_data=file_contents)
+        m_post.side_effect = TestComplete
+        with mock.patch("builtins.open", m_open):
+            with self.assertRaises(TestComplete):
+                lnd.create_wallet()
+        m_get.assert_not_called()
+        m_open.assert_called_with(lnd.SEED_FILENAME, "r")
+        # TODO: get the json-dumped value of the `data` dict from the post()
+        # calls, deserialize it, and check that the resulting dict contains the
+        # correct mnemonic.
+        # ...also check that post() was called with lnd.URL_INITWALLET and
+        # TLS_CERT_PATH
 
 
 if __name__ == "__main__":

--- a/tests/test_lnd.py
+++ b/tests/test_lnd.py
@@ -1,4 +1,4 @@
-'''Unit test template'''
+"""Unit test template"""
 import unittest
 import logging
 import random
@@ -6,65 +6,65 @@ from unittest import mock
 from noma import lnd
 
 PATCH_MODULES = [
-    'requests.get',
-    'requests.post',
-    'base64.b64encode',
-    'json.dumps',
-    'os.path',
+    "requests.get",
+    "requests.post",
+    "base64.b64encode",
+    "json.dumps",
+    "os.path",
 ]
 
 
 class Boom(Exception):
-    '''Raise me to stop the test, we're done'''
+    """Raise me to stop the test, we're done"""
+
     pass
 
 
 class Unhappy(Exception):
-    '''Something has gone wrong'''
+    """Something has gone wrong"""
+
     pass
 
 
 class LndCreateWalletTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.logger = logging.getLogger('root').getChild('lnd_test')
+        cls.logger = logging.getLogger("root").getChild("lnd_test")
 
     @classmethod
     def tearDownClass(cls):
         pass
 
     def setUp(self):
-        self.mocks = {
-            mod: mock.MagicMock() for mod in PATCH_MODULES
-        }
+        self.mocks = {mod: mock.MagicMock() for mod in PATCH_MODULES}
 
     def tearDown(self):
         pass
 
-    @mock.patch('os.path.exists')
+    @mock.patch("os.path.exists")
     def test_checks_path(self, m_exists):
-        '''Check create_walet() checks whether the SAVE_PASSWORD_CONTROL_FILE
-        exists'''
+        """Check create_walet() checks whether the SAVE_PASSWORD_CONTROL_FILE
+        exists"""
         m_exists.side_effect = Boom
         with self.assertRaises(Boom):
             lnd.create_wallet()
         m_exists.assert_called_with(lnd.SAVE_PASSWORD_CONTROL_FILE)
 
-    @mock.patch('noma.lnd.randompass')
-    @mock.patch('os.path.exists')
-    def test_generates_pass_and_opens_passfile(
-        self, m_exists, m_rpass
-    ):
+    @mock.patch("noma.lnd.randompass")
+    @mock.patch("os.path.exists")
+    def test_generates_pass_and_opens_passfile(self, m_exists, m_rpass):
         """
         Test that, if SAVE_PASSWORD_CONTROL_FILE does not exist, we call
         `randompass` and open the temp password file
         """
+
         def pass_control(call):
-            '''Checking for the file happens first, if we are called with any
-            other arg, something is wrong'''
+            """Checking for the file happens first, if we are called with any
+            other arg, something is wrong"""
             if call == lnd.SAVE_PASSWORD_CONTROL_FILE:
                 return False
             raise Unhappy(call)
+
         m_exists.side_effect = pass_control
         m_open = mock.mock_open()
         m_open.side_effect = Boom
@@ -75,11 +75,9 @@ class LndCreateWalletTests(unittest.TestCase):
         m_rpass.assert_called_with(string_length=15)
         m_open.assert_called_with(lnd.TEMP_PASSWORD_FILE_PATH, "w")
 
-    @mock.patch('noma.lnd.randompass')
-    @mock.patch('os.path.exists')
-    def test_uses_tempfile_if_no_controlfile(
-        self, m_exists, m_rpass
-    ):
+    @mock.patch("noma.lnd.randompass")
+    @mock.patch("os.path.exists")
+    def test_uses_tempfile_if_no_controlfile(self, m_exists, m_rpass):
         """
         Test that, if SESAME_PATH does not exist, and SAVE_PASS_CONTROL_FILE
         does not exist either, we:
@@ -88,10 +86,12 @@ class LndCreateWalletTests(unittest.TestCase):
             - write the generated password to the temp file, and
             - close the file
         """
+
         def exists(call):
             if call in (lnd.SAVE_PASSWORD_CONTROL_FILE, lnd.SESAME_PATH):
                 return False
             raise Unhappy(call)  # Should only have one of those calls
+
         m_exists.side_effect = exists
         m_open = mock.mock_open()
         m_rpass.return_value = random.random()
@@ -107,11 +107,9 @@ class LndCreateWalletTests(unittest.TestCase):
         handle.write.assert_called_with(m_rpass.return_value)
         handle.close.assert_called_with()
 
-    @mock.patch('noma.lnd.randompass')
-    @mock.patch('os.path.exists')
-    def test_uses_sesame_if_controlfile(
-        self, m_exists, m_rpass
-    ):
+    @mock.patch("noma.lnd.randompass")
+    @mock.patch("os.path.exists")
+    def test_uses_sesame_if_controlfile(self, m_exists, m_rpass):
         """
         Test that, if SESAME_PATH does not exist, and SAVE_PASS_CONTROL_FILE
         does exist, we:
@@ -120,12 +118,14 @@ class LndCreateWalletTests(unittest.TestCase):
             - write the generated password to the sesame file, and
             - close the file
         """
+
         def exists(call):
             if call == lnd.SESAME_PATH:
                 return False
             if call == lnd.SAVE_PASSWORD_CONTROL_FILE:
                 return True
             raise Unhappy(call)  # Should only have one of those calls
+
         m_exists.side_effect = exists
         m_open = mock.mock_open()
         m_rpass.return_value = random.random()
@@ -141,13 +141,14 @@ class LndCreateWalletTests(unittest.TestCase):
         handle.write.assert_called_with(m_rpass.return_value)
         handle.close.assert_called_with()
 
-    @mock.patch('os.path.exists')
+    @mock.patch("os.path.exists")
     def test_reads_sesame_if_exists(self, m_exists):
         """
         Test that, if SESAME_PATH does exist, we:
             - read the password_str from SESAME_PATH
             - .rstrip() the result
         """
+
         def exists(call):
             if call == lnd.SESAME_PATH:
                 return True
@@ -155,6 +156,7 @@ class LndCreateWalletTests(unittest.TestCase):
                 # Don't want to go into that logic either
                 return True
             raise Unhappy(call)  # Should only have one of those calls
+
         m_exists.side_effect = exists
         m_open = mock.mock_open()
         m_open.return_value = m_open_rv = mock.MagicMock()
@@ -173,5 +175,5 @@ class LndCreateWalletTests(unittest.TestCase):
         m_open_rv.read.rstrip.assert_called_with()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/test_lnd.py
+++ b/tests/test_lnd.py
@@ -205,7 +205,14 @@ class LndCreateWalletTests(unittest.TestCase):
         m_post.side_effect = TestComplete
         with mock.patch("builtins.open", m_open):
             with self.assertRaises(TestComplete):
-                lnd.create_wallet()
+                try:
+                    lnd.create_wallet()
+                except Unhappy as exc:
+                    raise Unhappy(
+                        "{}: {}\nget: {}\npost: {}".format(
+                            exc, m_exists.mock_calls, m_get.mock_calls,
+                            m_post.mock_calls)
+                    )
         m_get.assert_called_with(lnd.URL_GENSEED, verify=lnd.TLS_CERT_PATH)
         handle = m_open()
         for mne in mnemonic:

--- a/tests/test_lnd.py
+++ b/tests/test_lnd.py
@@ -1,8 +1,8 @@
 """Test LND functions"""
-import unittest
 import logging
 import random
 import json
+import unittest
 from unittest import mock
 from noma import lnd
 
@@ -10,16 +10,14 @@ from noma import lnd
 class TestComplete(Exception):
     """Raise me to stop the test, we're done"""
 
-    pass
-
 
 class Unhappy(Exception):
     """Something has gone wrong"""
 
-    pass
-
 
 class LndCreateWalletTests(unittest.TestCase):
+    """Test the create_wallet() function"""
+
     @classmethod
     def setUpClass(cls):
         cls.logger = logging.getLogger("root").getChild("lnd_test")
@@ -197,6 +195,7 @@ class LndCreateWalletTests(unittest.TestCase):
                 pass
 
             def json(self):
+                """mock JSON method"""
                 return {"cipher_seed_mnemonic": mnemonic}
 
         m_exists.side_effect = exists
@@ -210,8 +209,11 @@ class LndCreateWalletTests(unittest.TestCase):
                 except Unhappy as exc:
                     raise Unhappy(
                         "{}: {}\nget: {}\npost: {}".format(
-                            exc, m_exists.mock_calls, m_get.mock_calls,
-                            m_post.mock_calls)
+                            exc,
+                            m_exists.mock_calls,
+                            m_get.mock_calls,
+                            m_post.mock_calls,
+                        )
                     )
         m_get.assert_called_with(lnd.URL_GENSEED, verify=lnd.TLS_CERT_PATH)
         handle = m_open()

--- a/tests/test_lnd.py
+++ b/tests/test_lnd.py
@@ -1,0 +1,177 @@
+'''Unit test template'''
+import unittest
+import logging
+import random
+from unittest import mock
+from noma import lnd
+
+PATCH_MODULES = [
+    'requests.get',
+    'requests.post',
+    'base64.b64encode',
+    'json.dumps',
+    'os.path',
+]
+
+
+class Boom(Exception):
+    '''Raise me to stop the test, we're done'''
+    pass
+
+
+class Unhappy(Exception):
+    '''Something has gone wrong'''
+    pass
+
+
+class LndCreateWalletTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.logger = logging.getLogger('root').getChild('lnd_test')
+
+    @classmethod
+    def tearDownClass(cls):
+        pass
+
+    def setUp(self):
+        self.mocks = {
+            mod: mock.MagicMock() for mod in PATCH_MODULES
+        }
+
+    def tearDown(self):
+        pass
+
+    @mock.patch('os.path.exists')
+    def test_checks_path(self, m_exists):
+        '''Check create_walet() checks whether the SAVE_PASSWORD_CONTROL_FILE
+        exists'''
+        m_exists.side_effect = Boom
+        with self.assertRaises(Boom):
+            lnd.create_wallet()
+        m_exists.assert_called_with(lnd.SAVE_PASSWORD_CONTROL_FILE)
+
+    @mock.patch('noma.lnd.randompass')
+    @mock.patch('os.path.exists')
+    def test_generates_pass_and_opens_passfile(
+        self, m_exists, m_rpass
+    ):
+        """
+        Test that, if SAVE_PASSWORD_CONTROL_FILE does not exist, we call
+        `randompass` and open the temp password file
+        """
+        def pass_control(call):
+            '''Checking for the file happens first, if we are called with any
+            other arg, something is wrong'''
+            if call == lnd.SAVE_PASSWORD_CONTROL_FILE:
+                return False
+            raise Unhappy(call)
+        m_exists.side_effect = pass_control
+        m_open = mock.mock_open()
+        m_open.side_effect = Boom
+        with mock.patch("builtins.open", m_open):
+            with self.assertRaises(Boom):
+                lnd.create_wallet()
+        m_exists.assert_called_with(lnd.SAVE_PASSWORD_CONTROL_FILE)
+        m_rpass.assert_called_with(string_length=15)
+        m_open.assert_called_with(lnd.TEMP_PASSWORD_FILE_PATH, "w")
+
+    @mock.patch('noma.lnd.randompass')
+    @mock.patch('os.path.exists')
+    def test_uses_tempfile_if_no_controlfile(
+        self, m_exists, m_rpass
+    ):
+        """
+        Test that, if SESAME_PATH does not exist, and SAVE_PASS_CONTROL_FILE
+        does not exist either, we:
+            - generate the password with `randompass`,
+            - open the temporary password file
+            - write the generated password to the temp file, and
+            - close the file
+        """
+        def exists(call):
+            if call in (lnd.SAVE_PASSWORD_CONTROL_FILE, lnd.SESAME_PATH):
+                return False
+            raise Unhappy(call)  # Should only have one of those calls
+        m_exists.side_effect = exists
+        m_open = mock.mock_open()
+        m_rpass.return_value = random.random()
+        handle = m_open()
+        handle.close.side_effect = Boom
+        with mock.patch("builtins.open", m_open):
+            with self.assertRaises(Boom):
+                lnd.create_wallet()
+        m_exists.assert_any_call(lnd.SESAME_PATH)
+        m_exists.assert_any_call(lnd.SAVE_PASSWORD_CONTROL_FILE)
+        m_rpass.assert_called_with(string_length=15)
+        m_open.assert_called_with(lnd.TEMP_PASSWORD_FILE_PATH, "w")
+        handle.write.assert_called_with(m_rpass.return_value)
+        handle.close.assert_called_with()
+
+    @mock.patch('noma.lnd.randompass')
+    @mock.patch('os.path.exists')
+    def test_uses_sesame_if_controlfile(
+        self, m_exists, m_rpass
+    ):
+        """
+        Test that, if SESAME_PATH does not exist, and SAVE_PASS_CONTROL_FILE
+        does exist, we:
+            - generate the password with `randompass`,
+            - open the sesame file
+            - write the generated password to the sesame file, and
+            - close the file
+        """
+        def exists(call):
+            if call == lnd.SESAME_PATH:
+                return False
+            if call == lnd.SAVE_PASSWORD_CONTROL_FILE:
+                return True
+            raise Unhappy(call)  # Should only have one of those calls
+        m_exists.side_effect = exists
+        m_open = mock.mock_open()
+        m_rpass.return_value = random.random()
+        handle = m_open()
+        handle.close.side_effect = Boom
+        with mock.patch("builtins.open", m_open):
+            with self.assertRaises(Boom):
+                lnd.create_wallet()
+        m_exists.assert_any_call(lnd.SESAME_PATH)
+        m_exists.assert_any_call(lnd.SAVE_PASSWORD_CONTROL_FILE)
+        m_rpass.assert_called_with(string_length=15)
+        m_open.assert_called_with(lnd.SESAME_PATH, "w")
+        handle.write.assert_called_with(m_rpass.return_value)
+        handle.close.assert_called_with()
+
+    @mock.patch('os.path.exists')
+    def test_reads_sesame_if_exists(self, m_exists):
+        """
+        Test that, if SESAME_PATH does exist, we:
+            - read the password_str from SESAME_PATH
+            - .rstrip() the result
+        """
+        def exists(call):
+            if call == lnd.SESAME_PATH:
+                return True
+            if call == lnd.SAVE_PASSWORD_CONTROL_FILE:
+                # Don't want to go into that logic either
+                return True
+            raise Unhappy(call)  # Should only have one of those calls
+        m_exists.side_effect = exists
+        m_open = mock.mock_open()
+        m_open.return_value = m_open_rv = mock.MagicMock()
+        m_open_rv.read = mock.MagicMock()
+        m_open_rv.read.rstrip = mock.MagicMock()
+        m_open_rv.read.rstrip.side_effect = Boom
+        # TODO: calling open().read().rstrip() should raise the `Boom`
+        # exception but it currently does not, resulting in the code proceeding
+        # to encode the password and check whether SEED_FILENAME exists, at
+        # which point exists() (above) raises the `Unhappy` exception
+        with mock.patch("builtins.open", m_open):
+            with self.assertRaises(Boom):
+                lnd.create_wallet()
+        m_exists.assert_any_call(lnd.SESAME_PATH)
+        m_open.assert_called_with(lnd.SESAME_PATH, "w")
+        m_open_rv.read.rstrip.assert_called_with()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_lnd.py
+++ b/tests/test_lnd.py
@@ -1,4 +1,4 @@
-"""Unit test template"""
+"""Test LND functions"""
 import unittest
 import logging
 import random
@@ -129,7 +129,7 @@ class LndCreateWalletTests(unittest.TestCase):
         m_exists.assert_any_call(lnd.SESAME_PATH)
         m_open.assert_called_with(lnd.SESAME_PATH, "r")
 
-    @mock.patch("requests.get")
+    @mock.patch("noma.lnd.get")
     @mock.patch("os.path.exists")
     def test_generates_seed(self, m_exists, m_get):
         """
@@ -156,8 +156,8 @@ class LndCreateWalletTests(unittest.TestCase):
                 lnd.create_wallet()
         m_get.assert_called_with(lnd.URL_GENSEED, verify=lnd.TLS_CERT_PATH)
 
-    @mock.patch("requests.post")
-    @mock.patch("requests.get")
+    @mock.patch("noma.lnd.post")
+    @mock.patch("noma.lnd.get")
     @mock.patch("os.path.exists")
     def test_saves_seed(self, m_exists, m_get, m_post):
         """
@@ -219,8 +219,8 @@ class LndCreateWalletTests(unittest.TestCase):
             handle.write.assert_any_call(mne + "\n")
         handle.close.assert_called_with()
 
-    @mock.patch("requests.post")
-    @mock.patch("requests.get")
+    @mock.patch("noma.lnd.post")
+    @mock.patch("noma.lnd.get")
     @mock.patch("os.path.exists")
     def test_loads_seed(self, m_exists, m_get, m_post):
         """

--- a/tests/test_lnd.py
+++ b/tests/test_lnd.py
@@ -254,10 +254,10 @@ class LndCreateWalletTests(unittest.TestCase):
         post_call = m_post.mock_calls[-1]
         _, args, kwargs = post_call
         self.assertIn(lnd.URL_INITWALLET, args)
-        self.assertEqual(kwargs['verify'], lnd.TLS_CERT_PATH)
-        data_json = kwargs['data']
+        self.assertEqual(kwargs["verify"], lnd.TLS_CERT_PATH)
+        data_json = kwargs["data"]
         data = json.loads(data_json)
-        self.assertEqual(data['cipher_seed_mnemonic'], mnemonic)
+        self.assertEqual(data["cipher_seed_mnemonic"], mnemonic)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fix line lengths to pep8-compliant 79 chars, and break out constants from create_wallet() ahead of writing tests. This will make testing easier at a later stage (since we can reference module.CONSTANT_NAME in unit tests)

Please test this PR before merging, I have not got `noma` set up locally yet for "live" testing!