### PR TITLE
scp channel backup

### DIFF
--- a/noma/config.py
+++ b/noma/config.py
@@ -12,10 +12,15 @@ LND_MODE = "neutrino"
 LND_NET = "mainnet"
 
 """Filesystem"""
-
 MEDIA_PATH = Path("/media")
 NOMA_SOURCE = MEDIA_PATH / "noma"
 
+"""Remote SSH backup host"""
+SSH_PORT = "22"
+# Make sure to use a passphrase-less private key
+SSH_IDENTITY = "~/.ssh/id_ed25519"
+# [user@]host:[path]
+SSH_TARGET = "user@ssh-hostname:/path/to/backup/dir/"
 
 """Do not change below here"""
 """unless you know what you're doing"""
@@ -32,6 +37,7 @@ TLS_CERT_PATH = LND_PATH / "tls.cert"
 
 MACAROON_PATH = CHAIN_PATH / LND_NET / "admin.macaroon"
 SEED_FILENAME = LND_PATH / "seed.txt"
+CHANNEL_BACKUP = CHAIN_PATH / LND_NET / "channel.backup"
 
 """LND Create Password"""
 # Save password control file (Add this file to save passwords)
@@ -46,4 +52,3 @@ URL_GENSEED = "https://127.0.0.1:8080/v1/genseed"
 # Initialize wallet
 URL_INITWALLET = "https://127.0.0.1:8080/v1/initwallet"
 URL_UNLOCKWALLET = "https://127.0.0.1:8080/v1/unlockwallet"
-

--- a/noma/lnd.py
+++ b/noma/lnd.py
@@ -2,7 +2,7 @@
 LND related functionality
 """
 import pathlib
-from subprocess import call
+from subprocess import call, run
 from os import path
 from json import dumps
 import base64
@@ -202,9 +202,21 @@ def check():
 
 def backup():
     """Export and backup latest channel.db from lnd via ssh"""
-    # TODO: wallet/channel backup
-    # remote backups via ssh or rsync
-    print("Not implemented yet")
+    # secure remote backups via scp
+    if cfg.CHANNEL_BACKUP.is_file():
+        # scp options:
+        # -B for non-interactive batch mode
+        # -p to preserve modification & access time, modes
+        complete = run(["scp",
+                        "-B",
+                        "-i {}".format(cfg.SSH_IDENTITY),
+                        "-p",
+                        "-P {}".format(cfg.SSH_PORT),
+                        "{}".format(cfg.CHANNEL_BACKUP),
+                        "{}".format(cfg.SSH_TARGET)])
+        return complete.returncode
+    print("Error: channel.backup not found")
+    return exit(1)
 
 
 def savepeers():


### PR DESCRIPTION
This PR adds a simple command `noma lnd backup` that uses scp to send `channel.backup` via ssh to a host defined in `config.py`

Users will need to configure the location of a passphrase-less SSH private key in `config.py` and prepare the target host with pubkey & writable directory