### PR TITLE
Bitcoin full node support

### DIFF
--- a/bitcoind/bitcoin.conf
+++ b/bitcoind/bitcoin.conf
@@ -6,15 +6,18 @@ maxmempool=50
 # Reduce storage requirements by only storing most recent N MiB of block. This mode is incompatible with -txindex and -rescan. WARNING: Reverting this setting requires re-downloading the entire blockchain. (default: 0 = disable pruning blocks, 1 = allow manual pruning via RPC, greater than 550 = automatically prune blocks to stay under target size in MiB).
 prune=550
 
+# Uncomment to change default block and chainstate directories
+#datadir=/datadir
+
 # [network]
 # Bind to given address and always listen on it. Use [host]:port notation for IPv6.
 bind=0.0.0.0
 # Maintain at most N connections to peers.
-maxconnections=40
+maxconnections=8
 # Tries to keep outbound traffic under the given target (in MiB per 24h), 0 = no limit.
-maxuploadtarget=5000
+maxuploadtarget=1000
 # Use separate SOCKS5 proxy <ip:port> to reach peers via Tor hidden services.
-onion=127.0.0.1:9050
+#onion=127.0.0.1:9050
 
 # [rpc]
 # Accept command line and JSON-RPC commands.
@@ -28,11 +31,3 @@ rpcauth=lncm:salt$hash
 rpcport=8332
 # Allow JSON-RPC connections from specified source. Valid for <ip> are a single IP (e.g. 1.2.3.4), a network/netmask (e.g. 1.2.3.4/255.255.255.0) or a network/CIDR (e.g. 1.2.3.4/24). This option can be specified multiple times.
 rpcallowip=127.0.0.1
-rpcallowip=192.168.0.1/24
-rpcallowip=192.168.1.1/24
-rpcallowip=10.0.0.0/8
-rpcallowip=172.16.0.0/12
-rpcallowip=172.18.0.0/16
-
-# Reserved for generating RPC auth
-GENERATEDRPCAUTH

--- a/compose/fullnode/docker-compose.yml
+++ b/compose/fullnode/docker-compose.yml
@@ -1,0 +1,29 @@
+version: '3.7'
+services:
+  bitcoind:
+    image: lncm/bitcoind:0.18
+    volumes:
+      - /media/noma/bitcoind:/root/.bitcoin
+    restart: on-failure
+    network_mode: host
+
+  lnd:
+    image: lncm/lnd:0.7.1-experimental-watchtower-neutrino
+    volumes:
+      - /media/noma/lnd/neutrino:/root/.lnd
+      - /media/noma/lnd/neutrino/lnd.conf:/home/lncm/.lnd/lnd.conf
+    restart: on-failure
+    network_mode: host
+
+  invoicer:
+    image: lncm/invoicer:v0.6.2
+    volumes:
+      - /media/noma/invoicer:/root/.lncm
+      - /media/noma/lnd/neutrino:/lnd
+      - /media/noma/public_html:/static
+      - /media/noma/invoicer:/logs
+    depends_on:
+      - bitcoind
+      - lnd
+    restart: on-failure
+    network_mode: host


### PR DESCRIPTION
This adds a pruned `bitcoind` with low resource limits.

Intended to provide `invoicer` with mempool capabilities and block verification.

Please note that pruned mode will sync from genesis unless a recent chain snapshot is applied.

TODO:
- [ ] Generate rpcauth for bitcoin.conf
- [ ] Automatically populate invoicer.conf with credentials