### PR TITLE
Fix for #67: apt remove python3-requests on debian systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,14 @@ sudo noma start
 ```
 Note: You may need to use `pip3` instead of `pip`
 
-For convenience `install.sh` may be used to bootstrap Python 3, Docker and Noma on Debian-based and Alpine systems.
+For convenience `install.sh` may be used to bootstrap Python 3, Docker and Noma on Debian-based and Alpine systems:
+```
+cd /media
+sudo chown -R $USER .
+git clone https://github.com/lncm/noma.git
+cd noma
+sudo ./install.sh
+```
 
 ### Windows
 

--- a/install.sh
+++ b/install.sh
@@ -35,6 +35,9 @@ debian_install() {
     # apt dependencies
     apt-get install -y python3-pip python3-cffi libffi-dev libssl-dev
 
+    # Some Debians come with an old version of requests
+    apt-get remove -y python3-requests
+
     # check if source keyword exists to guard against bashism
     if type source >/dev/null 2>&1; then
         # reload profile to update PATH

--- a/noma/lnd.py
+++ b/noma/lnd.py
@@ -85,7 +85,7 @@ def connectstring(
 def autounlock():
     """Auto-unlock lnd using password.txt, tls.cert"""
 
-    password_str = open(cfg.PASSWORD_FILE_PATH, "r").read().rstrip()
+    password_str = open(str(cfg.PASSWORD_FILE_PATH), "r").read().rstrip()
     password_bytes = str(password_str).encode("utf-8")
     data = {"wallet_password": base64.b64encode(password_bytes).decode()}
     try:
@@ -261,7 +261,7 @@ def _write_password(password_str):
         temp_password_file.close()
     else:
         # Use password.txt if password_control_file exists
-        password_file = open(cfg.PASSWORD_FILE_PATH, "w")
+        password_file = open(str(cfg.PASSWORD_FILE_PATH), "w")
         password_file.write(password_str)
         password_file.close()
 

--- a/noma/lnd.py
+++ b/noma/lnd.py
@@ -254,9 +254,9 @@ def _write_password(password_str):
     """Write a generated password to file, either the TEMP_PASSWORD_FILE_PATH
     or the PASSWORD_FILE_PATH depending on whether SAVE_PASSWORD_CONTROL_FILE
     exists."""
-    if not path.exists(cfg.SAVE_PASSWORD_CONTROL_FILE):
+    if not path.exists(str(cfg.SAVE_PASSWORD_CONTROL_FILE)):
         # Use temporary file if there is a password control file there
-        temp_password_file = open(cfg.PASSWORD_FILE_PATH, "w")
+        temp_password_file = open(str(cfg.PASSWORD_FILE_PATH), "w")
         temp_password_file.write(password_str)
         temp_password_file.close()
     else:
@@ -270,24 +270,24 @@ def _wallet_password():
     """Either load the wallet password from PASSWORD_FILE_PATH, or generate a new
     password, save it to file, and in either case return the password"""
     # Check if there is an existing file, if not generate a random password
-    if not path.exists(cfg.PASSWORD_FILE_PATH):
+    if not path.exists(str(cfg.PASSWORD_FILE_PATH)):
         # password file doesnt exist
         password_str = randompass(string_length=15)
         _write_password(password_str)
     else:
         # Get password from file if password file already exists
-        password_str = open(cfg.PASSWORD_FILE_PATH, "r").read().rstrip()
+        password_str = open(str(cfg.PASSWORD_FILE_PATH), "r").read().rstrip()
     return password_str
 
 
 def _generate_and_save_seed():
     """Generate a wallet seed, save it to SEED_FILENAME, and return it"""
     mnemonic = None
-    return_data = get(cfg.URL_GENSEED, verify=cfg.TLS_CERT_PATH)
+    return_data = get(cfg.URL_GENSEED, verify=str(cfg.TLS_CERT_PATH))
     if return_data.status_code == 200:
         json_seed_creation = return_data.json()
         mnemonic = json_seed_creation["cipher_seed_mnemonic"]
-        seed_file = open(cfg.SEED_FILENAME, "w")
+        seed_file = open(str(cfg.SEED_FILENAME), "w")
         for word in mnemonic:
             seed_file.write(word + "\n")
         seed_file.close()
@@ -299,7 +299,7 @@ def _generate_and_save_seed():
 def _load_seed():
     """Load the wallet seed from SEED_FILENAME and return it"""
     # Seed exists
-    seed_file = open(cfg.SEED_FILENAME, "r")
+    seed_file = open(str(cfg.SEED_FILENAME), "r")
     seed_file_words = seed_file.readlines()
     mnemonic = []
     for importword in seed_file_words:
@@ -313,7 +313,7 @@ def _wallet_data(password_str):
     # Convert password to byte encoded
     password_bytes = str(password_str).encode("utf-8")
     # Send request to generate seed if seed file doesnt exist
-    if not path.exists(cfg.SEED_FILENAME):
+    if not path.exists(str(cfg.SEED_FILENAME)):
         mnemonic = _generate_and_save_seed()
     else:
         mnemonic = _load_seed()
@@ -347,7 +347,7 @@ def create_wallet():
     if data:
         # Data is defined so proceed
         return_data = post(
-            cfg.URL_INITWALLET, verify=cfg.TLS_CERT_PATH, data=dumps(data)
+            cfg.URL_INITWALLET, verify=str(cfg.TLS_CERT_PATH), data=dumps(data)
         )
         if return_data.status_code == 200:
             print("✅ Create wallet is successful")

--- a/noma/node.py
+++ b/noma/node.py
@@ -63,7 +63,7 @@ def start():
         print("Fetching compose from noma repo")
         get_source()
 
-    os.chdir(cfg.COMPOSE_MODE_PATH)
+    os.chdir(cfg.COMPOSE_MODE_PATH.as_posix())
     call(["docker-compose", "up", "-d"])
 
 

--- a/noma/node.py
+++ b/noma/node.py
@@ -63,7 +63,7 @@ def start():
         print("Fetching compose from noma repo")
         get_source()
 
-    os.chdir(cfg.COMPOSE_MODE_PATH.as_posix())
+    os.chdir(str(cfg.COMPOSE_MODE_PATH))
     call(["docker-compose", "up", "-d"])
 
 

--- a/tests/test_lnd.py
+++ b/tests/test_lnd.py
@@ -46,7 +46,10 @@ class LndCreateWalletTests(unittest.TestCase):
         """
 
         def exists(call):
-            if call in (cfg.SAVE_PASSWORD_CONTROL_FILE, cfg.PASSWORD_FILE_PATH):
+            if call in (
+                    str(cfg.SAVE_PASSWORD_CONTROL_FILE),
+                    str(cfg.PASSWORD_FILE_PATH),
+            ):
                 return False
             raise Unhappy(call)  # Should only have one of those calls
 
@@ -58,10 +61,10 @@ class LndCreateWalletTests(unittest.TestCase):
         with mock.patch("builtins.open", m_open):
             with self.assertRaises(TestComplete):
                 lnd.create_wallet()
-        m_exists.assert_any_call(cfg.PASSWORD_FILE_PATH)
-        m_exists.assert_any_call(cfg.SAVE_PASSWORD_CONTROL_FILE)
+        m_exists.assert_any_call(str(cfg.PASSWORD_FILE_PATH))
+        m_exists.assert_any_call(str(cfg.SAVE_PASSWORD_CONTROL_FILE))
         m_rpass.assert_called_with(string_length=15)
-        m_open.assert_called_with(cfg.PASSWORD_FILE_PATH, "w")
+        m_open.assert_called_with(str(cfg.PASSWORD_FILE_PATH), "w")
         handle.write.assert_called_with(m_rpass.return_value)
         handle.close.assert_called_with()
 

--- a/tests/test_lnd.py
+++ b/tests/test_lnd.py
@@ -81,9 +81,9 @@ class LndCreateWalletTests(unittest.TestCase):
         """
 
         def exists(call):
-            if call == cfg.PASSWORD_FILE_PATH:
+            if call == str(cfg.PASSWORD_FILE_PATH):
                 return False
-            if call == cfg.SAVE_PASSWORD_CONTROL_FILE:
+            if call == str(cfg.SAVE_PASSWORD_CONTROL_FILE):
                 return True
             raise Unhappy(call)  # Should only have one of those calls
 
@@ -95,10 +95,10 @@ class LndCreateWalletTests(unittest.TestCase):
         with mock.patch("builtins.open", m_open):
             with self.assertRaises(TestComplete):
                 lnd.create_wallet()
-        m_exists.assert_any_call(cfg.PASSWORD_FILE_PATH)
-        m_exists.assert_any_call(cfg.SAVE_PASSWORD_CONTROL_FILE)
+        m_exists.assert_any_call(str(cfg.PASSWORD_FILE_PATH))
+        m_exists.assert_any_call(str(cfg.SAVE_PASSWORD_CONTROL_FILE))
         m_rpass.assert_called_with(string_length=15)
-        m_open.assert_called_with(cfg.PASSWORD_FILE_PATH, "w")
+        m_open.assert_called_with(str(cfg.PASSWORD_FILE_PATH), "w")
         handle.write.assert_called_with(m_rpass.return_value)
         handle.close.assert_called_with()
 
@@ -112,12 +112,12 @@ class LndCreateWalletTests(unittest.TestCase):
         """
 
         def exists(call):
-            if call == cfg.PASSWORD_FILE_PATH:
+            if call == str(cfg.PASSWORD_FILE_PATH):
                 return True
-            if call == cfg.SAVE_PASSWORD_CONTROL_FILE:
+            if call == str(cfg.SAVE_PASSWORD_CONTROL_FILE):
                 # Don't want to go into that logic either
                 return True
-            if call == cfg.SEED_FILENAME:
+            if call == str(cfg.SEED_FILENAME):
                 raise TestComplete
             raise Unhappy(call)  # Should only have one of those calls
 
@@ -126,10 +126,10 @@ class LndCreateWalletTests(unittest.TestCase):
         with mock.patch("builtins.open", m_open):
             with self.assertRaises(TestComplete):
                 lnd.create_wallet()
-        password_call = mock.call(cfg.PASSWORD_FILE_PATH, "r").read()
+        password_call = mock.call(str(cfg.PASSWORD_FILE_PATH), "r").read()
         self.assertIn(password_call, m_open.mock_calls)
-        m_exists.assert_any_call(cfg.PASSWORD_FILE_PATH)
-        m_open.assert_called_with(cfg.PASSWORD_FILE_PATH, "r")
+        m_exists.assert_any_call(str(cfg.PASSWORD_FILE_PATH))
+        m_open.assert_called_with(str(cfg.PASSWORD_FILE_PATH), "r")
 
     @mock.patch("noma.lnd.get")
     @mock.patch("os.path.exists")
@@ -141,12 +141,12 @@ class LndCreateWalletTests(unittest.TestCase):
         """
 
         def exists(call):
-            if call == cfg.PASSWORD_FILE_PATH:
+            if call == str(cfg.PASSWORD_FILE_PATH):
                 return True
-            if call == cfg.SAVE_PASSWORD_CONTROL_FILE:
+            if call == str(cfg.SAVE_PASSWORD_CONTROL_FILE):
                 # Don't want to go into that logic either
                 return True
-            if call == cfg.SEED_FILENAME:
+            if call == str(cfg.SEED_FILENAME):
                 return False
             raise Unhappy(call)  # Should only have one of those calls
 
@@ -156,7 +156,7 @@ class LndCreateWalletTests(unittest.TestCase):
         with mock.patch("builtins.open", m_open):
             with self.assertRaises(TestComplete):
                 lnd.create_wallet()
-        m_get.assert_called_with(cfg.URL_GENSEED, verify=cfg.TLS_CERT_PATH)
+        m_get.assert_called_with(cfg.URL_GENSEED, verify=str(cfg.TLS_CERT_PATH))
 
     @mock.patch("noma.lnd.post")
     @mock.patch("noma.lnd.get")
@@ -179,12 +179,12 @@ class LndCreateWalletTests(unittest.TestCase):
         """
 
         def exists(call):
-            if call == cfg.PASSWORD_FILE_PATH:
+            if call == str(cfg.PASSWORD_FILE_PATH):
                 return True
-            if call == cfg.SAVE_PASSWORD_CONTROL_FILE:
+            if call == str(cfg.SAVE_PASSWORD_CONTROL_FILE):
                 # Don't want to go into that logic either
                 return True
-            if call == cfg.SEED_FILENAME:
+            if call == str(cfg.SEED_FILENAME):
                 return False
             raise Unhappy(call)  # Should only have one of those calls
 
@@ -219,7 +219,7 @@ class LndCreateWalletTests(unittest.TestCase):
                             m_post.mock_calls,
                         )
                     )
-        m_get.assert_called_with(cfg.URL_GENSEED, verify=cfg.TLS_CERT_PATH)
+        m_get.assert_called_with(cfg.URL_GENSEED, verify=str(cfg.TLS_CERT_PATH))
         handle = m_open()
         for mne in mnemonic:
             handle.write.assert_any_call(mne + "\n")
@@ -245,12 +245,12 @@ class LndCreateWalletTests(unittest.TestCase):
         """
 
         def exists(call):
-            if call == cfg.PASSWORD_FILE_PATH:
+            if call == str(cfg.PASSWORD_FILE_PATH):
                 return True
-            if call == cfg.SAVE_PASSWORD_CONTROL_FILE:
+            if call == str(cfg.SAVE_PASSWORD_CONTROL_FILE):
                 # Don't want to go into that logic either
                 return True
-            if call == cfg.SEED_FILENAME:
+            if call == str(cfg.SEED_FILENAME):
                 return True
             raise Unhappy(call)  # Should only have one of those calls
 
@@ -263,11 +263,11 @@ class LndCreateWalletTests(unittest.TestCase):
             with self.assertRaises(TestComplete):
                 lnd.create_wallet()
         m_get.assert_not_called()
-        m_open.assert_called_with(cfg.SEED_FILENAME, "r")
+        m_open.assert_called_with(str(cfg.SEED_FILENAME), "r")
         post_call = m_post.mock_calls[-1]
         _, args, kwargs = post_call
         self.assertIn(cfg.URL_INITWALLET, args)
-        self.assertEqual(kwargs["verify"], cfg.TLS_CERT_PATH)
+        self.assertEqual(kwargs["verify"], str(cfg.TLS_CERT_PATH))
         data_json = kwargs["data"]
         data = json.loads(data_json)
         self.assertEqual(data["cipher_seed_mnemonic"], mnemonic)


### PR DESCRIPTION
Modify `install.sh` to apt remove python3-requests, if found, when run on debian systems. The packaged version is too old for us. pip3 will then install a newer version of requests later on in the installation process