### PR TITLE
Fix for #67: apt remove python3-requests on debian systems

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -35,6 +35,9 @@ debian_install() {
     # apt dependencies
     apt-get install -y python3-pip python3-cffi libffi-dev libssl-dev
 
+    # Some Debians come with an old version of requests
+    apt-get remove -y python3-requests
+
     # check if source keyword exists to guard against bashism
     if type source >/dev/null 2>&1; then
         # reload profile to update PATH


### PR DESCRIPTION
Modify install.sh to apt remove python3-requests, if found, when run on debian systems. The packaged version is too old for us. pip3 will then install a newer version of requests later on in the installation process