### PR TITLE
Add online help system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,3 +132,6 @@ dmypy.json
 .pyre/
 
 \.DS_Store
+
+# Dropped by noma?
+public_html

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -45,6 +45,7 @@ extensions = [
     "sphinx.ext.coverage",
     "sphinx.ext.viewcode",
     "recommonmark",
+    "sphinx.ext.napoleon",
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -32,20 +32,18 @@ Command-line Usage
 
 **lnd**::
 
-  noma lnd (start|stop|info)
-  noma lnd logs [--tail]
-  noma lnd connect <address>
-  noma lnd (create|unlock|status|check)
-  noma lnd lncli [<command>...]
-  noma lnd get <key> [<section>] [<path>]
-  noma lnd set <key> <value> [<section>] [<path>]
+  noma lnd create
+  noma lnd backup
   noma lnd autounlock
   noma lnd autoconnect [<path>]
-  noma lnd lndconnectapp <hostport>
-  noma lnd lndconnectstring <hostport>
+  noma lnd savepeers
+  noma lnd connectapp <hostport>
+  noma lnd connectstring <hostport>
+
 
 **noma**::
 
+  noma help [COMMAND]
   noma (-h|--help)
   noma --version
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,43 +13,7 @@ CLI utility and Python API to manage bitcoin lightning nodes.
 
 Command-line Usage
 ==================
-**node**::
-
-  noma (info|start|stop|restart|logs|check|status)
-  noma (temp|swap|ram)
-  noma (freq|memory|voltage) [<device>]
-  noma usb-setup
-  noma tunnel <port> <host>
-  noma (backup|restore|source|diff|devtools)
-  noma reinstall [--full]
-
-**bitcoind**::
-
-  noma bitcoind (start|stop|info|fastsync|status|check)
-  noma bitcoind get <key>
-  noma bitcoind set <key> <value>
-  noma bitcoind logs [--tail]
-
-**lnd**::
-
-  noma lnd create
-  noma lnd backup
-  noma lnd autounlock
-  noma lnd autoconnect [<path>]
-  noma lnd savepeers
-  noma lnd connectapp <hostport>
-  noma lnd connectstring <hostport>
-
-
-**noma**::
-
-  noma help [COMMAND]
-  noma (-h|--help)
-  noma --version
-
-   Options:
-  -h --help     Show this screen.
-  --version     Show version.
+.. automodule:: noma.noma
 
 API Modules
 ===========
@@ -57,32 +21,12 @@ API Modules
 node
 ----
 .. automodule:: noma.node
-   :members:
-
-bitcoind
---------
-.. automodule:: noma.bitcoind
-   :members:
+   :members: start, stop, check, logs, info
 
 lnd
 ---
 .. automodule:: noma.lnd
-   :members:
-
-install
--------
-.. automodule:: noma.install
-   :members:
-
-usb
----
-.. automodule:: noma.usb
-   :members:
-
-rpcauth
--------
-.. automodule:: noma.rpcauth
-   :members:
+   :members: create, backup, autounlock, autoconnect, savepeers, connectapp, connectstring
 
 Indices and tables
 ==================

--- a/docs/install_manpage.sh
+++ b/docs/install_manpage.sh
@@ -1,10 +1,11 @@
-#!/bin/bash
+#!/bin/sh
 
 # build and install manpage for noma
 set -eu
 
 MANPAGE="noma.1"
 MAN_DIR="/usr/local/man/man1"
+MAN_DIR_ALPINE="/usr/share/man/man1"
 
 
 check_root() {
@@ -21,11 +22,23 @@ check_directory() {
     fi
 }
 
+alpine_os() {
+    if [ -f "/etc/alpine-release" ]; then
+        return 0
+    fi
+}
+
 check_root
 check_directory
+
+if [ alpine_os ]; then
+    MAN_DIR=$MAN_DIR_ALPINE
+fi
 
 cd docs
 sphinx-build . _build -b man
 install -g 0 -o 0 -m 0644 _build/$MANPAGE $MAN_DIR
 gzip ${MAN_DIR}/${MANPAGE}
-mandb
+if [ ! alpine_os ]; then
+    mandb
+fi

--- a/docs/install_manpage.sh
+++ b/docs/install_manpage.sh
@@ -24,7 +24,7 @@ check_directory() {
 
 alpine_os() {
     if [ -f "/etc/alpine-release" ]; then
-        return 0
+        return
     fi
 }
 
@@ -39,6 +39,7 @@ cd docs
 sphinx-build . _build -b man
 install -g 0 -o 0 -m 0644 _build/$MANPAGE $MAN_DIR
 gzip ${MAN_DIR}/${MANPAGE}
+
 if [ ! alpine_os ]; then
     mandb
 fi

--- a/docs/install_manpage.sh
+++ b/docs/install_manpage.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# build and install manpage for noma
+set -eu
+
+MANPAGE="noma.1"
+MAN_DIR="/usr/local/man/man1"
+
+
+check_root() {
+    if [ "$(id -u)" != "0" ]; then
+       echo "Error: You must be root to install"
+       exit 1
+    fi
+}
+
+check_directory() {
+    if [ ! -d "docs" ]; then
+        echo "Error: must be run from the noma root directory (e.g 'docs/install_manpage.sh')"
+        exit 1
+    fi
+}
+
+check_root
+check_directory
+
+cd docs
+sphinx-build . _build -b man
+install -g 0 -o 0 -m 0644 _build/$MANPAGE $MAN_DIR
+gzip ${MAN_DIR}/${MANPAGE}
+mandb

--- a/install.sh
+++ b/install.sh
@@ -53,6 +53,9 @@ debian_install() {
 
     # noma
     python3 setup.py develop
+    
+    # Install manpage
+    docs/install_manpage.sh
 }
 
 start_noma() {

--- a/noma/install.py
+++ b/noma/install.py
@@ -42,9 +42,7 @@ def move_cache(cache_dir="/media/mmcblk0p1/cache", var_cache="/var/cache/apk"):
         if setup.returncode == 0:
             print("setup-apkcache was successful")
         else:
-            raise OSError(
-                "setup-apkcache was not successful \n" + setup.stdout
-            )
+            raise OSError("setup-apkcache was not successful \n" + setup.stdout)
         return setup.returncode
 
 
@@ -79,18 +77,14 @@ def install_apk_deps():
 def mnt_ext4(device, path):
     """Mount device at path using ext4"""
     exitcode = call(
-        ["mount", "-t ext4", "/dev/" + device, path],
-        stdout=DEVNULL,
-        stdin=DEVNULL,
+        ["mount", "-t ext4", "/dev/" + device, path], stdout=DEVNULL, stdin=DEVNULL
     )
     return exitcode
 
 
 def mnt_any(device, path):
     """Mount device at path using any filesystem"""
-    exitcode = call(
-        ["mount", "/dev/" + device, path], stdout=DEVNULL, stdin=DEVNULL
-    )
+    exitcode = call(["mount", "/dev/" + device, path], stdout=DEVNULL, stdin=DEVNULL)
     return exitcode
 
 
@@ -118,11 +112,7 @@ def check_for_destruction(device, path):
     destroy = Path(path + "/DESTROY_ALL_DATA_ON_THIS_DEVICE/").is_dir()
     if destroy:
         print("Destruction flag found!")
-        print(
-            "Going to destroy all data on /dev/{} in 3 seconds...".format(
-                device
-            )
-        )
+        print("Going to destroy all data on /dev/{} in 3 seconds...".format(device))
         sleep(3)
         unmounted = call(["umount", "/dev/" + device])
         if unmounted and not usb.is_mounted(device):
@@ -130,9 +120,7 @@ def check_for_destruction(device, path):
             call(["mkfs.ext4", "-F", "/dev/" + device])
             if mnt_ext4(device, path) == 0 and usb.is_mounted(device):
                 print(
-                    "{d} formatted with ext4 successfully and mounted.".format(
-                        d=device
-                    )
+                    "{d} formatted with ext4 successfully and mounted.".format(d=device)
                 )
                 return True
         else:
@@ -176,17 +164,9 @@ def fallback_mount(partition, path):
     print("Attempting to mount with any filesystem...")
 
     if mnt_any(partition, path) == 0 and usb.is_mounted(partition):
-        print(
-            "{d} mounted at {p} with any filesystem".format(
-                d=partition, p=path
-            )
-        )
+        print("{d} mounted at {p} with any filesystem".format(d=partition, p=path))
         return True
-    print(
-        "Error: {} usb is not mountable with any supported format".format(
-            partition
-        )
-    )
+    print("Error: {} usb is not mountable with any supported format".format(partition))
     print("Cannot continue without all USB storage devices")
     return False
 
@@ -201,9 +181,7 @@ def setup_fstab(device, mount):
             )
             file.write(fstab)
     else:
-        print(
-            "Warning: {} usb does not seem to be ext4 formatted".format(device)
-        )
+        print("Warning: {} usb does not seem to be ext4 formatted".format(device))
         print("{} will not be added to /etc/fstab".format(device))
 
 
@@ -237,23 +215,18 @@ def create_swap():
 
         if dd.returncode != 0:
             # dd has non-zero exit code
-            raise OSError(
-                "Warning: dd cannot create swap file \n" + str(dd.stdout)
-            )
+            raise OSError("Warning: dd cannot create swap file \n" + str(dd.stdout))
         return True
 
     def mk_swap():
         mkswap = run(
-            ["mkswap", "/media/volatile/volatile/swap"],
-            stdout=PIPE,
-            stderr=STDOUT,
+            ["mkswap", "/media/volatile/volatile/swap"], stdout=PIPE, stderr=STDOUT
         )
 
         if mkswap.returncode != 0:
             # mkswap has non-zero exit code
             raise OSError(
-                "Warning: mkswap could not create swap file \n"
-                + str(mkswap.stdout)
+                "Warning: mkswap could not create swap file \n" + str(mkswap.stdout)
             )
         return True
 
@@ -343,16 +316,10 @@ def usb_setup():
                         # We confirmed device is mountable, readable, writable
                         setup_fstab(device, mountpoints[num])
             else:
-                print(
-                    "Mounting {d} with any filesystem unsuccessful".format(
-                        d=device
-                    )
-                )
+                print("Mounting {d} with any filesystem unsuccessful".format(d=device))
                 exit(1)
         else:
-            print(
-                "Error: {p} directory not available".format(p=mountpoints[num])
-            )
+            print("Error: {p} directory not available".format(p=mountpoints[num]))
             exit(1)
 
     def setup_volatile():
@@ -371,14 +338,12 @@ def usb_setup():
             noma.bitcoind.create()
             if noma.bitcoind.check():
                 noma.bitcoind.set_prune("550")
-                noma.bitcoind.set_rpcauth(
-                    "/media/archive/archive/bitcoin/bitcoin.conf"
-                )
+                noma.bitcoind.set_rpcauth("/media/archive/archive/bitcoin/bitcoin.conf")
 
             import noma.lnd
 
             print("Creating lnd files")
-            noma.lnd.check_wallet()
+            noma.lnd.create()
             if noma.lnd.check():
                 noma.lnd.setup_tor()
 
@@ -461,8 +426,8 @@ def install_box():
         noma.node.start()
         install_crontab()
         if noma.lnd.check():
-            print("Checking lnd wallet")
-            noma.lnd.check_wallet()
+            print("Creating lnd wallet")
+            noma.lnd.create()
 
     print("Removing post-install from default runlevel")
     call(["rc-update", "del", "lncm-post", "default"])

--- a/noma/lnd.py
+++ b/noma/lnd.py
@@ -10,7 +10,7 @@ from requests import get, post
 import noma.config as cfg
 
 
-def check_wallet():
+def create():
     """
     This will either import an existing seed (or our own generated one),
     or use LND to create one.
@@ -51,19 +51,13 @@ def encodemacaroons(macaroonfile=cfg.MACAROON_PATH, tlsfile=cfg.TLS_CERT_PATH):
         )
         tlsencoded = tlstrim.encode("utf-8")
 
-        return {
-            "status": "OK",
-            "certificate": tlsencoded,
-            "macaroon": macaroonencoded,
-        }
+        return {"status": "OK", "certificate": tlsencoded, "macaroon": macaroonencoded}
     else:
         return {"status": "File Not Found"}
 
 
 def connectstring(
-    hostname=cfg.URL_GRPC,
-    macaroonfile=cfg.MACAROON_PATH,
-    tlsfile=cfg.TLS_CERT_PATH,
+    hostname=cfg.URL_GRPC, macaroonfile=cfg.MACAROON_PATH, tlsfile=cfg.TLS_CERT_PATH
 ):
     """Show lndconnect string for remote wallets such as Zap"""
     result = encodemacaroons(macaroonfile, tlsfile)

--- a/noma/lnd.py
+++ b/noma/lnd.py
@@ -223,13 +223,17 @@ def backup():
         # scp options:
         # -B for non-interactive batch mode
         # -p to preserve modification & access time, modes
-        complete = run(["scp",
-                        "-B",
-                        "-i {}".format(cfg.SSH_IDENTITY),
-                        "-p",
-                        "-P {}".format(cfg.SSH_PORT),
-                        "{}".format(cfg.CHANNEL_BACKUP),
-                        "{}".format(cfg.SSH_TARGET)])
+        complete = run(
+            [
+                "scp",
+                "-B",
+                "-i {}".format(cfg.SSH_IDENTITY),
+                "-p",
+                "-P {}".format(cfg.SSH_PORT),
+                "{}".format(cfg.CHANNEL_BACKUP),
+                "{}".format(cfg.SSH_TARGET),
+            ]
+        )
         return complete.returncode
     print("Error: channel.backup not found")
     return exit(1)
@@ -331,12 +335,13 @@ def create_wallet():
     1. Check if there's already a wallet. If there is, then exit.
     2. Check for password.txt
     3. If doesn't exist then check for whether we should save the password
-    (SAVE_PASSWORD_CONTROL_FILE exists) or not
+       (SAVE_PASSWORD_CONTROL_FILE exists) or not
     4. If password.txt exists import password in.
     5. If password.txt doesn't exist and we don't save the password, create a
-    password and save it in temporary path as defined in PASSWORD_FILE_PATH
+       password and save it in temporary path as defined in PASSWORD_FILE_PATH
     6. Now start the wallet creation. Look for a seed defined in SEED_FILENAME,
-    if not existing then generate a wallet based on the seed by LND.
+       if not existing then generate a wallet based on the seed by LND.
+
     """
     password_str = _wallet_password()
 

--- a/noma/noma.py
+++ b/noma/noma.py
@@ -41,7 +41,10 @@ def _help(cmd):
     - get rid of the hacky if-then logic
     - come up with a more professional catch-all help expression.
     """
-    if cmd:
+    if not cmd:
+        help(node)
+        return
+    else:
         base = cmd[0]
         if base in dir(node):
             help(getattr(node, base))

--- a/noma/noma.py
+++ b/noma/noma.py
@@ -13,6 +13,7 @@ Usage:  noma start
         noma lnd savepeers
         noma lnd connectapp
         noma lnd connectstring
+        noma help [COMMAND]
         noma (-h|--help)
         noma --version
 
@@ -68,6 +69,9 @@ def node_fn(args):
 
     elif args["check"]:
         node.check()
+
+    elif args["help"]:
+        print("{} ??? HELP !!!". format(args['COMMAND'].upper()))
 
 
 def main():

--- a/noma/noma.py
+++ b/noma/noma.py
@@ -13,7 +13,7 @@ Usage:  noma start
         noma lnd savepeers
         noma lnd connectapp
         noma lnd connectstring
-        noma help [COMMAND]
+        noma help [COMMAND]...
         noma (-h|--help)
         noma --version
 
@@ -26,6 +26,37 @@ import os
 from docopt import docopt
 from noma import lnd
 from noma import node
+
+
+def _help(cmd):
+    """
+    Display help for a given command using docstrings.
+    TODO:
+    - do this using proper documentation instead of the current help() hack.
+      (currently it shows all kinds of non-public functions which are not
+      recognised commands if you do e.g `sudo noma help lnd`
+    - handle the discrepancy between `lnd create` and the called function
+      (lnd.check_wallet()) properly... this probably means renaming
+      lnd.check_wallet() to lnd.create()
+    - get rid of the hacky if-then logic
+    - come up with a more professional catch-all help expression.
+    """
+    if cmd:
+        base = cmd[0]
+        if base in dir(node):
+            help(getattr(node, cmd))
+            return
+        elif len(cmd) > 1:
+            cmd_2 = cmd[1]
+            if base == 'lnd' and cmd_2 in dir(lnd):
+                if cmd_2 == 'create':
+                    help(lnd.check_wallet)
+                else:
+                    help(getattr(lnd, cmd_2))
+                return
+        elif base == 'lnd':
+            help(lnd)
+    print("{} ??? HELP !!!". format(cmd))
 
 
 def lnd_fn(args):
@@ -71,7 +102,7 @@ def node_fn(args):
         node.check()
 
     elif args["help"]:
-        print("{} ??? HELP !!!". format(args['COMMAND'].upper()))
+        _help(args['COMMAND'])
 
 
 def main():

--- a/noma/noma.py
+++ b/noma/noma.py
@@ -32,14 +32,11 @@ def _help(cmd):
     """
     Display help for a given command using docstrings.
     TODO:
-    - do this using proper documentation instead of the current help() hack.
-      (currently it shows all kinds of non-public functions which are not
-      recognised commands if you do e.g `sudo noma help lnd`
+    - figure out how to hide private functions
     - handle the discrepancy between `lnd create` and the called function
-      (lnd.check_wallet()) properly... this probably means renaming
-      lnd.check_wallet() to lnd.create()
+      (lnd.create()) properly... this probably means renaming
+      lnd.create() to lnd.create()
     - get rid of the hacky if-then logic
-    - come up with a more professional catch-all help expression.
     """
     if not cmd:
         help(node)
@@ -53,7 +50,7 @@ def _help(cmd):
             cmd_2 = cmd[1]
             if base == "lnd":
                 if cmd_2 == "create":
-                    help(lnd.check_wallet)
+                    help(lnd.create)
                     return
                 elif cmd_2 in dir(lnd):
                     help(getattr(lnd, cmd_2))
@@ -61,7 +58,7 @@ def _help(cmd):
         elif base == "lnd":
             help(lnd)
             return
-    print("{} ??? HELP !!!".format(cmd))
+    print("Unknown help option: {}".format(cmd))
 
 
 def lnd_fn(args):
@@ -69,7 +66,7 @@ def lnd_fn(args):
     lnd related functionality
     """
     if args["create"]:
-        lnd.check_wallet()
+        lnd.create()
 
     elif args["autounlock"]:
         lnd.autounlock()

--- a/noma/noma.py
+++ b/noma/noma.py
@@ -44,7 +44,7 @@ def _help(cmd):
     if cmd:
         base = cmd[0]
         if base in dir(node):
-            help(getattr(node, cmd))
+            help(getattr(node, base))
             return
         elif len(cmd) > 1:
             cmd_2 = cmd[1]

--- a/noma/noma.py
+++ b/noma/noma.py
@@ -33,9 +33,6 @@ def _help(cmd):
     Display help for a given command using docstrings.
     TODO:
     - figure out how to hide private functions
-    - handle the discrepancy between `lnd create` and the called function
-      (lnd.create()) properly... this probably means renaming
-      lnd.create() to lnd.create()
     - get rid of the hacky if-then logic
     """
     if not cmd:
@@ -49,10 +46,7 @@ def _help(cmd):
         elif len(cmd) > 1:
             cmd_2 = cmd[1]
             if base == "lnd":
-                if cmd_2 == "create":
-                    help(lnd.create)
-                    return
-                elif cmd_2 in dir(lnd):
+                if cmd_2 in dir(lnd):
                     help(getattr(lnd, cmd_2))
                     return
         elif base == "lnd":

--- a/noma/noma.py
+++ b/noma/noma.py
@@ -48,14 +48,16 @@ def _help(cmd):
             return
         elif len(cmd) > 1:
             cmd_2 = cmd[1]
-            if base == 'lnd' and cmd_2 in dir(lnd):
+            if base == 'lnd':
                 if cmd_2 == 'create':
                     help(lnd.check_wallet)
-                else:
+                    return
+                elif cmd_2 in dir(lnd):
                     help(getattr(lnd, cmd_2))
-                return
+                    return
         elif base == 'lnd':
             help(lnd)
+            return
     print("{} ??? HELP !!!". format(cmd))
 
 

--- a/noma/noma.py
+++ b/noma/noma.py
@@ -48,17 +48,17 @@ def _help(cmd):
             return
         elif len(cmd) > 1:
             cmd_2 = cmd[1]
-            if base == 'lnd':
-                if cmd_2 == 'create':
+            if base == "lnd":
+                if cmd_2 == "create":
                     help(lnd.check_wallet)
                     return
                 elif cmd_2 in dir(lnd):
                     help(getattr(lnd, cmd_2))
                     return
-        elif base == 'lnd':
+        elif base == "lnd":
             help(lnd)
             return
-    print("{} ??? HELP !!!". format(cmd))
+    print("{} ??? HELP !!!".format(cmd))
 
 
 def lnd_fn(args):
@@ -104,7 +104,7 @@ def node_fn(args):
         node.check()
 
     elif args["help"]:
-        _help(args['COMMAND'])
+        _help(args["COMMAND"])
 
 
 def main():

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ setup(
         "sphinx_rtd_theme",
         "recommonmark",
         "sphinx",
+        "sphinxcontrib-napoleon",
     ],
     entry_points={"console_scripts": ["noma = noma.noma:main"]},
     # metadata to display on PyPI

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,15 @@ setup(
     name="noma",
     version="0.5.1",
     packages=["noma"],
-    install_requires=["psutil", "docopt", "requests", "docker-compose"],
+    install_requires=[
+        "psutil",
+        "docopt",
+        "requests",
+        "docker-compose",
+        "sphinx_rtd_theme",
+        "recommonmark",
+        "sphinx",
+    ],
     entry_points={"console_scripts": ["noma = noma.noma:main"]},
     # metadata to display on PyPI
     zip_safe=True,


### PR DESCRIPTION
Add an online help system as per #73.
Todo:

- [x]  Add man page
- [ ]  Make documentation conform to [man page format](https://www.cyberciti.biz/faq/linux-unix-creating-a-manpage/) or create a separate manpage file that automagically updates from the main documentation
- [x]  Add man page installation support for non-debian distributions


Very much a WIP right now. Command-specific help may not be worth doing (and may add unnecessary overhead in terms of keeping documentation updated) if the manpage works well.